### PR TITLE
Fix trivial typos

### DIFF
--- a/source/_posts/SciCoCom-Roundup-2.md
+++ b/source/_posts/SciCoCom-Roundup-2.md
@@ -33,7 +33,7 @@ They can be found in:
 * National labs and large facilities
 * or can simply be the post-doc everyone turns to for help.
 
-One difficulty can be recognising the role for example in a recent survey of  10,000 academic jobs advertised in the UK they found about 400 were software related or had a software development component. Thats good - but they also found 194 different job titles!
+One difficulty can be recognising the role for example in a recent survey of  10,000 academic jobs advertised in the UK they found about 400 were software related or had a software development component. That's good - but they also found 194 different job titles!
 
 ### A brief history:
 * 2010 - Software sustainability institute. - 4 uk unis, better software, better research
@@ -112,7 +112,7 @@ There's not much to say - go work through the demo and examples and have some fu
 
 # Creating the chaotic sandpit, giving corporate IT the right tools and freedom to support science. - Jonathon Flutey, (Johnny) Victoria University, Wellington
 
-Traditional core IT has key drivers of stabilty and security along with limited resources. This tends to result in systems that are locked down, not flexible, and not available when needed.
+Traditional core IT has key drivers of stability and security along with limited resources. This tends to result in systems that are locked down, not flexible, and not available when needed.
 
 Victoria Uni created a [Vision and strategy for Digital learning and Teaching 2012 to 2017](https://www.google.co.nz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0ahUKEwi5ydXExLrVAhUBLJQKHZ0PDxEQFgglMAA&url=http%3A%2F%2Fwww.victoria.ac.nz%2Flearning-teaching%2Fpartnership%2Ftechnology%2Fdigital-vision-strategy.pdf&usg=AFQjCNEwiSvAW0DVQz6VoFJ_n9Qas4Hlmw)
 
@@ -151,7 +151,7 @@ They identified three levels of platform sophistication and formality:
   * Evaluation, assessment, pilot, transitioning
   * collaboration between research and formal IT
   * AWS, Azure, Catalyst Cloud, Docker, private cloud
-  * live testing, scaling up, persistant storage, privacy
+  * live testing, scaling up, persistent storage, privacy
   * available in days, months life cycle - project scale
   * Experimental
   * But may have privacy and security concerns so more care required
@@ -165,7 +165,7 @@ They identified three levels of platform sophistication and formality:
   * Azure, VMWare, Physical SOE servers
   * security
   * built for production - weeks?
-  * long term persistance
+  * long term persistence
 
 May need to put containers into long term digital preservation system.
 
@@ -211,7 +211,7 @@ This was not a particularly complex optimisation the key there is simply having 
 
 
 # Closing
-Nick Jones from NeSI gave a glimpse of whats coming soon for NZ researchers and developers in the form of new supercomputers. Rather than repeat it here take a look at https://www.nesi.org.nz/news/2017/06/new-computing-platform-power-nz-research
+Nick Jones from NeSI gave a glimpse of what's coming soon for NZ researchers and developers in the form of new supercomputers. Rather than repeat it here take a look at https://www.nesi.org.nz/news/2017/06/new-computing-platform-power-nz-research
 
 Finally I closed the conference with a brief summary of the above and some new things I needed to go home and investigate:
 New terms

--- a/source/_posts/SciCoCom-Roundup.md
+++ b/source/_posts/SciCoCom-Roundup.md
@@ -81,7 +81,7 @@ Here are some of the common themes:
 	* For all the talk of advanced technology a lot of benefit from moving up one step on the maturity model - e.g start using version control.
 	* Some organisations are data rich but information poor, they have a multitude of data sets that are hard to discover, lack clear documentation and data models, lack processes and the means to analyse, and there is a lack of experienced data science capability.
 * Legacy code & Silos
-	 * Some organisations have very long running systems, e.g. Nationally Significant databases. These promote extreme conservatism and resistance to change. There is a requirement for long term statistics - whether for climate or job figures to be consistantly produced the same way each year.
+	 * Some organisations have very long running systems, e.g. Nationally Significant databases. These promote extreme conservatism and resistance to change. There is a requirement for long term statistics - whether for climate or job figures to be consistently produced the same way each year.
    * Older systems have often evolved over time and have no as built description or design documentation.
 * Labour costs massively outweigh compute equipment costs, yet the nature of IT budgets is that a researcher may have to work with a slow PC or wait weeks for access to online resources.
 * How easy is it for scientists to
@@ -212,7 +212,7 @@ Uwe demonstrated how modern languages and frameworks now typically come with too
 
 This is a major shift from the days when many novices would create new projects based on template code abstracted from how-to's and tutorials. These projects often would be configured for simplicity and getting started rather than generating a production ready system.
 
-Uwe demonstrated [Angular](https://angular.io/) in conjuction with a node.js package [Angular-cli](https://github.com/angular/angular-cli) a command line interface for generating and managing angular projects.
+Uwe demonstrated [Angular](https://angular.io/) in conjunction with a node.js package [Angular-cli](https://github.com/angular/angular-cli) a command line interface for generating and managing angular projects.
 
 Although hampered rather by the VGA projector, Uwe was able to live demo installation of the tool chain and generation of a first project.  This project comes ready configure with end to end testing and unit testing capabilities so you can start writing fully tested applications from day one - by far the easiest way.
 

--- a/source/_posts/SciCoCon.md
+++ b/source/_posts/SciCoCon.md
@@ -15,4 +15,4 @@ Wellington Central, Wellington 6021
 
 I'll be tweeting #SciCoCon2017
 
-This will be attended by both pro software developers and science coders and its an opportuntity to meet peers and talk about tools, techniques, processes and challenges associated with developing robust scientific code and applications.
+This will be attended by both pro software developers and science coders and it's an opportunity to meet peers and talk about tools, techniques, processes and challenges associated with developing robust scientific code and applications.

--- a/source/quotes/index.md
+++ b/source/quotes/index.md
@@ -35,7 +35,7 @@ No one can prevent that
 {% endblockquote %}
 
 ## Thorny people
-In every group of people: families, teams, communities there are thorns that annoy. Its not always necessary to point out their faults - As my wise wife says - "Do you want to be right or in a relationship".
+In every group of people: families, teams, communities there are thorns that annoy. It's not always necessary to point out their faults - As my wise wife says - "Do you want to be right or in a relationship".
 
 {% blockquote Mediations, Marcus Aurelius, Book 4, trans Gregory Hayes %}
 What’s there to complain about? People’s misbehavior?
@@ -52,11 +52,11 @@ But take into consideration:
 This version of keep it simple applies to the way we live our lives - but it also applies to good software design. Do what is essential, ask is this necessary.
 
 {% blockquote Mediations, Marcus Aurelius, Book 4, trans Gregory Hayes %}
-"If you seek tranquility, do less", Or (more accurately) do what's essential - what the logos of a social being requires, and in the requisite way. While brings a double satisfaction: to do less, better.
+"If you seek tranquillity, do less", Or (more accurately) do what's essential - what the logos of a social being requires, and in the requisite way. While brings a double satisfaction: to do less, better.
 
 Because most of what we say and do is not essential. If you can eliminate it, you'll have more time, and more tranquillity. Ask yourself at every moment, "Is this necessary?"
 
-But we need to eliminate unnecessary assumptions as well. To eliminate the unecessary actions that follow.
+But we need to eliminate unnecessary assumptions as well. To eliminate the unnecessary actions that follow.
 {% endblockquote %}
 
 # Physics

--- a/source/resume/index.md
+++ b/source/resume/index.md
@@ -93,7 +93,7 @@ Monitoring apparatus for monitoring traffic flow in a tunnel, Golden River Ltd, 
 
 Resource files for electronic devices, Sendo, WO 2002041139 A3, https://www.google.com/patents/WO2002041139A3
 
-Device for automatically extending text messages, and methods therefor, Sendo, US 20050180392 A1, https://www.google.com/patents/US20050180392
+Device for automatically extending text messages, and methods therefore, Sendo, US 20050180392 A1, https://www.google.com/patents/US20050180392
 
 Method of Determining a Rendezvous and Related Personal Navigation Device, Navman, US 20100161210 A1, https://www.google.com/patents/US20100161210
 


### PR DESCRIPTION
Not a native speaker, so feel free to discard the pull request if necessary, and cherry-pick any changes that can be applied.

Found one typo in the resume or timeline I think, and then scanned `*.md` files with [`mwic`](http://jwilk.net/software/mwic).

Hope it helps, and thanks for the great write-up about the SciCoCon conference!

Bruno